### PR TITLE
Fix pandas 3.0 tz-aware datetime compat

### DIFF
--- a/quant/data/storage.py
+++ b/quant/data/storage.py
@@ -63,8 +63,8 @@ class DataStorage:
         path = self._cache_path(symbol, interval)
         cached = self._read_parquet(path)
 
-        start_ts = pd.Timestamp(start, tz="UTC")
-        end_ts = pd.Timestamp(end, tz="UTC")
+        start_ts = pd.Timestamp(start).tz_localize("UTC") if pd.Timestamp(start).tz is None else pd.Timestamp(start).tz_convert("UTC")
+        end_ts = pd.Timestamp(end).tz_localize("UTC") if pd.Timestamp(end).tz is None else pd.Timestamp(end).tz_convert("UTC")
 
         if cached is not None and not cached.empty:
             cache_start = cached.index.min()


### PR DESCRIPTION
## Summary
- Fixes `pd.Timestamp(dt, tz="UTC")` crash on pandas 3.0 when `dt` is already tz-aware
- Affected file: `quant/data/storage.py` line 66-67
- Now checks `.tz` before calling `tz_localize()` or `tz_convert()`

## Test plan
- [x] `python scripts/download_data.py --assets AAPL --interval 1d --days 365` succeeds
- [x] `pytest tests/ -v` — 217/217 pass